### PR TITLE
Simplify the stored representation of `UnixTime`

### DIFF
--- a/include/UnixStamp.hpp
+++ b/include/UnixStamp.hpp
@@ -25,29 +25,17 @@
 class UnixStamp
 {
 private:
-    // Both timestamps are saved in GMT+0
+    // The timestamp is in GMT+0
     unixstamp unix;
-    civil_time time;
-    int8_t tz;
 
 public:
     UnixStamp(unixstamp initialUnix);
-    UnixStamp(unixstamp initialUnix, int8_t initialTz);
     UnixStamp(civil_time intialTime);
     UnixStamp(civil_time intialTime, int8_t initialTz);
 
-    civil_time getOriginalTime();
     civil_time getTimeInTz(int8_t tz);
 
     unixstamp getUnix();
-    civil_time getTime();
-    int8_t getTz();
-    uint16_t getYear();
-    uint8_t getMonth();
-    uint8_t getDay();
-    uint8_t getHour();
-    uint8_t getMinute();
-    uint8_t getSecond();
 
     // Convert civil time in timezone 'tz' to the unix timestamp in GMT+0
     static unixstamp convertTimeToUnix(civil_time time, int8_t tz);

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,6 +13,7 @@ test_framework = unity
 
 [env:nanoatmega328]
 platform = atmelavr
+build_flags = -std=c++11
 board = nanoatmega328
 framework = arduino
 test_build_src = true
@@ -21,6 +22,7 @@ test_filter =
 
 [env:native]
 platform = native
+build_flags = -std=c++11
 test_build_src = true
 test_filter =
   common/*

--- a/src/UnixStamp.cpp
+++ b/src/UnixStamp.cpp
@@ -1,23 +1,10 @@
 #include "UnixStamp.hpp"
 
-UnixStamp::UnixStamp(unixstamp inintialUnix) : UnixStamp(inintialUnix, 0) {}
+UnixStamp::UnixStamp(unixstamp unix) : unix(unix) {}
 
-UnixStamp::UnixStamp(unixstamp inintialUnix, int8_t inintialTz)
-{
-    this->tz = inintialTz;
-    this->unix = inintialUnix - (inintialTz * ONE_HOUR_IN_SEC);
-    this->time = convertUnixToTime(inintialUnix, inintialTz);
-}
+UnixStamp::UnixStamp(civil_time time) : UnixStamp(time, 0) {}
 
-UnixStamp::UnixStamp(civil_time initialTime) : UnixStamp(initialTime, 0) {}
-
-
-UnixStamp::UnixStamp(civil_time initialTime, int8_t initialTz)
-{
-    this->tz = initialTz;
-    this->unix = convertTimeToUnix(initialTime, initialTz);
-    this->time = initialTz != 0 ? convertUnixToTime(this->unix, 0) : initialTime;
-}
+UnixStamp::UnixStamp(civil_time time, int8_t tz) : unix(convertTimeToUnix(time, tz)) {}
 
 unixstamp UnixStamp::convertTimeToUnix(civil_time timeToConvert, int8_t fromTz)
 {
@@ -64,11 +51,6 @@ civil_time UnixStamp::convertUnixToTime(unixstamp unixToConvert, int8_t fromTz)
     return time;
 }
 
-civil_time UnixStamp::getOriginalTime()
-{
-    return convertUnixToTime(this->unix, this->tz);
-}
-
 civil_time UnixStamp::getTimeInTz(int8_t tz)
 {
     return convertUnixToTime(this->unix, tz);
@@ -77,44 +59,4 @@ civil_time UnixStamp::getTimeInTz(int8_t tz)
 unixstamp UnixStamp::getUnix()
 {
     return this->unix;
-}
-
-int8_t UnixStamp::getTz()
-{
-    return this->tz;
-}
-
-civil_time UnixStamp::getTime()
-{
-    return this->time;
-}
-
-uint16_t UnixStamp::getYear()
-{
-    return this->time.year;
-}
-
-uint8_t UnixStamp::getMonth()
-{
-    return this->time.mon;
-}
-
-uint8_t UnixStamp::getDay()
-{
-    return this->time.day;
-}
-
-uint8_t UnixStamp::getHour()
-{
-    return this->time.hour;
-}
-
-uint8_t UnixStamp::getMinute()
-{
-    return this->time.min;
-}
-
-uint8_t UnixStamp::getSecond()
-{
-    return this->time.sec;
 }

--- a/test/common/test_lib/UnixStampTest.cpp
+++ b/test/common/test_lib/UnixStampTest.cpp
@@ -90,7 +90,7 @@ void test_unix_stamp_object_from_unix_date()
 {
     civil_time expected_date{45, 23, 21, 25, 4, 1986};
     UnixStamp unixStamp(EXPECETED_CHERNOBYL_TIMESTAMP);
-    verify_date(expected_date, unixStamp.getTime());
+    verify_date(expected_date, unixStamp.getTimeInTz(0));
 }
 
 void test_unix_stamp_object_from_unix_in_gmt()
@@ -110,20 +110,7 @@ void test_unix_stamp_object_from_civil_date_in_gmt()
 {
     civil_time time{45, 23, 21, 25, 4, 1986};
     UnixStamp unixStamp(time);
-    verify_date(time, unixStamp.getTime());
-}
-
-void test_tz_equal_unix_constructor()
-{
-    UnixStamp unixStamp(EXPECETED_CHERNOBYL_TIMESTAMP, 4);
-    TEST_ASSERT_EQUAL(4, unixStamp.getTz());
-}
-
-void test_tz_equal_time_constructor()
-{
-    civil_time time{45, 23, 21, 25, 4, 1986};
-    UnixStamp unixStamp(time, 4);
-    TEST_ASSERT_EQUAL(4, unixStamp.getTz());
+    verify_date(time, unixStamp.getTimeInTz(0));
 }
 
 int main(void)
@@ -134,8 +121,6 @@ int main(void)
     RUN_TEST(test_unix_stamp_object_from_unix_in_gmt);
     RUN_TEST(test_unix_stamp_object_from_civil_unix);
     RUN_TEST(test_unix_stamp_object_from_civil_date_in_gmt);
-    RUN_TEST(test_tz_equal_time_constructor);
-    RUN_TEST(test_tz_equal_unix_constructor);
 
     RUN_TEST(test_conversion_to_unix_unix_left_border);
     RUN_TEST(test_conversion_to_unix_unix_right_border);
@@ -148,5 +133,6 @@ int main(void)
     RUN_TEST(test_conversion_to_civil_chernobyl);
     RUN_TEST(test_conversion_to_civil_calendar_era_end);
     RUN_TEST(test_conversion_to_civil_calendar_era_start);
+
     return UNITY_END();
 }


### PR DESCRIPTION
Store only a timestamp (`unixstamp`), not date-time components (`civil_time`).

Some rationale is laid out in #5. If the said rationale is accepted, please consider this change-set as a practical implementation thereof.

Resolves #5